### PR TITLE
feat: add opacity keyPath to animations tab

### DIFF
--- a/apps/web/components/editor/canvas-preview.tsx
+++ b/apps/web/components/editor/canvas-preview.tsx
@@ -535,6 +535,11 @@ export function CanvasPreview() {
       const b = Number(values[seg + 1] ?? a);
       const ny = lerp(a, b, f);
       (l as any).rotationY = ny;
+    } else if (keyPath === 'opacity') {
+      const a = Number(values[seg] ?? (l as any).opacity ?? 1);
+      const b = Number(values[seg + 1] ?? a);
+      const nop = lerp(a, b, f);
+      (l as any).opacity = nop;
     }
   };
 

--- a/apps/web/components/editor/inspector/tabs/AnimationsTab.tsx
+++ b/apps/web/components/editor/inspector/tabs/AnimationsTab.tsx
@@ -7,6 +7,7 @@ import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { InspectorTabProps } from "../types";
+import type { KeyPath } from "@/lib/ca/types";
 
 interface AnimationsTabProps extends InspectorTabProps {
   animEnabled: boolean;
@@ -43,7 +44,7 @@ export function AnimationsTab({
                     if ((selectedBase as any)?.type === 'video') return;
                     const enabled = !!checked;
                     const currentAnim = (selectedBase as any)?.animations || {};
-                    const kp = (currentAnim.keyPath ?? 'position') as 'position' | 'position.x' | 'position.y' | 'transform.rotation.x' | 'transform.rotation.y' | 'transform.rotation.z';
+                    const kp = (currentAnim.keyPath ?? 'position') as KeyPath;
                     let values: Array<{ x: number; y: number } | number> = Array.isArray(currentAnim.values) ? [...currentAnim.values] : [];
                     if (enabled && values.length === 0) {
                       if (kp === 'position') {
@@ -54,6 +55,8 @@ export function AnimationsTab({
                         values = [((selectedBase as any).position?.y ?? 0) as number];
                       } else if (kp === 'transform.rotation.z') {
                         values = [Number((selectedBase as any)?.rotation ?? 0)];
+                      } else if (kp === 'opacity') {
+                        values = [Number((selectedBase as any)?.opacity ?? 1)];
                       } else {
                         values = [0];
                       }
@@ -75,7 +78,7 @@ export function AnimationsTab({
               if ((selectedBase as any)?.type === 'video') return;
               const enabled = !!checked;
               const currentAnim = (selectedBase as any)?.animations || {};
-              const kp = (currentAnim.keyPath ?? 'position') as 'position' | 'position.x' | 'position.y' | 'transform.rotation.x' | 'transform.rotation.y' | 'transform.rotation.z';
+              const kp = (currentAnim.keyPath ?? 'position') as KeyPath;
               let values: Array<{ x: number; y: number } | number> = Array.isArray(currentAnim.values) ? [...currentAnim.values] : [];
               if (enabled && values.length === 0) {
                 if (kp === 'position') {
@@ -86,6 +89,8 @@ export function AnimationsTab({
                   values = [((selectedBase as any).position?.y ?? 0) as number];
                 } else if (kp === 'transform.rotation.z') {
                   values = [Number((selectedBase as any)?.rotation ?? 0)];
+                } else if (kp === 'opacity') {
+                  values = [Number((selectedBase as any)?.opacity ?? 1)];
                 } else {
                   values = [0];
                 }
@@ -102,7 +107,7 @@ export function AnimationsTab({
             value={((selectedBase as any)?.animations?.keyPath ?? 'position') as any}
             onValueChange={(v) => {
               const current = (selectedBase as any)?.animations || {};
-              const kp = v as 'position' | 'position.x' | 'position.y' | 'transform.rotation.x' | 'transform.rotation.y' | 'transform.rotation.z';
+              const kp = v as KeyPath;
               const prevVals = (current.values || []) as Array<{ x: number; y: number } | number>;
               let values: Array<{ x: number; y: number } | number> = [];
               if (kp === 'position') {
@@ -119,6 +124,8 @@ export function AnimationsTab({
               } else if (kp === 'transform.rotation.z' || kp === 'transform.rotation.x' || kp === 'transform.rotation.y') {
                 const fallback = (kp === 'transform.rotation.z') ? Number((selectedBase as any)?.rotation ?? 0) : 0;
                 values = prevVals.map((pv: any) => typeof pv === 'number' ? pv : fallback);
+              } else if (kp === 'opacity') {
+                values = prevVals.map((pv: any) => Number((selectedBase as any)?.opacity ?? 1));
               }
               updateLayer(selectedBase!.id, { animations: { ...current, keyPath: kp, values } } as any);
             }}
@@ -134,6 +141,7 @@ export function AnimationsTab({
               <SelectItem value="transform.rotation.x">transform.rotation.x</SelectItem>
               <SelectItem value="transform.rotation.y">transform.rotation.y</SelectItem>
               <SelectItem value="transform.rotation.z">transform.rotation.z</SelectItem>
+              <SelectItem value="opacity">opacity</SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -215,9 +223,10 @@ export function AnimationsTab({
         <div className="flex items-center justify-between">
           <Label>
             {(() => {
-              const kp = ((selectedBase as any)?.animations?.keyPath ?? 'position') as string;
+              const kp = ((selectedBase as any)?.animations?.keyPath ?? 'position') as KeyPath;
               if (kp.startsWith('transform.rotation')) return 'Values (Degrees)';
               if (kp === 'position') return 'Values (CGPoint)';
+              if (kp === 'opacity') return 'Values (Percentage)';
               return 'Values (Number)';
             })()}
           </Label>
@@ -227,7 +236,7 @@ export function AnimationsTab({
             variant="secondary"
             onClick={() => {
               const current = (selectedBase as any)?.animations || {};
-              const kp = (current.keyPath ?? 'position') as 'position' | 'position.x' | 'position.y' | 'transform.rotation.x' | 'transform.rotation.y' | 'transform.rotation.z';
+              const kp = (current.keyPath ?? 'position') as KeyPath;
               const values = [...(current.values || [])] as any[];
               if (kp === 'position') {
                 values.push({ x: (selectedBase as any).position?.x ?? 0, y: (selectedBase as any).position?.y ?? 0 });
@@ -239,6 +248,8 @@ export function AnimationsTab({
                 values.push(Number((selectedBase as any)?.rotation ?? 0));
               } else if (kp === 'transform.rotation.x' || kp === 'transform.rotation.y') {
                 values.push(0);
+              } else if (kp === 'opacity') {
+                values.push(Number((selectedBase as any)?.opacity ?? 1));
               }
               updateLayer(selectedBase!.id, { animations: { ...current, values } } as any);
             }}
@@ -249,7 +260,7 @@ export function AnimationsTab({
         </div>
         <div className={`space-y-2 ${animEnabled ? '' : 'opacity-50'}`}>
           {(() => {
-            const kp = ((selectedBase as any)?.animations?.keyPath ?? 'position') as 'position' | 'position.x' | 'position.y' | 'transform.rotation.x' | 'transform.rotation.y' | 'transform.rotation.z';
+            const kp = ((selectedBase as any)?.animations?.keyPath ?? 'position') as KeyPath;
             const values = (((selectedBase as any)?.animations?.values || []) as Array<any>);
             if (kp === 'position') {
               return (
@@ -318,22 +329,33 @@ export function AnimationsTab({
                 {values.map((val, idx) => (
                   <div key={idx} className="grid grid-cols-2 gap-2 items-end">
                     <div className="space-y-1">
-                      <Label className="text-xs">{kp === 'position.x' ? 'X' : kp === 'position.y' ? 'Y' : 'Degrees'}</Label>
-                      <Input
-                        type="number"
-                        step="1"
-                        className="h-8"
-                        value={Number.isFinite(Number(val)) ? String(Math.round(Number(val))) : ''}
-                        onChange={(e) => {
-                          const v = e.target.value;
-                          const current = (selectedBase as any)?.animations || {};
-                          const arr = [...(current.values || [])];
-                          const n = Number(v);
-                          arr[idx] = Number.isFinite(n) ? n : 0;
-                          updateLayer(selectedBase!.id, { animations: { ...current, values: arr } } as any);
-                        }}
-                        disabled={!animEnabled}
-                      />
+                      <Label className="text-xs">
+                        {kp === 'position.x' ? 'X' : kp === 'position.y' ? 'Y' : kp === 'opacity' ? 'Opacity' : 'Degrees'}
+                      </Label>
+                      <div className="flex items-center gap-2">
+                        <Input
+                          type="number"
+                          step="1"
+                          className="h-8"
+                          value={kp === 'opacity' ? String(Math.round((typeof val === 'number' ? val : 1) * 100)) : Number.isFinite(Number(val)) ? String(Math.round(Number(val))) : ''}
+                          onChange={(e) => {
+                            const v = e.target.value;
+                            const current = (selectedBase as any)?.animations || {};
+                            const arr = [...(current.values || [])];
+                            const n = Number(v);
+                            if (kp === 'opacity') {
+                              const p = Math.max(0, Math.min(100, Math.round(n)));
+                              const val = Math.round(p) / 100;
+                              arr[idx] = val;
+                            } else {
+                              arr[idx] = Number.isFinite(n) ? n : 0;
+                            }
+                            updateLayer(selectedBase!.id, { animations: { ...current, values: arr } } as any);
+                          }}
+                          disabled={!animEnabled}
+                        />
+                        {kp === 'opacity' && <span className="text-xs text-muted-foreground">%</span>}
+                      </div>
                     </div>
                     <div className="flex items-center justify-end pb-0.5">
                       <Button

--- a/apps/web/lib/ca/types.ts
+++ b/apps/web/lib/ca/types.ts
@@ -32,15 +32,7 @@ export type LayerBase = {
   geometryFlipped?: 0 | 1;
   // Clip contents for sublayers to this layer's bounds (0 = off, 1 = on)
   masksToBounds?: 0 | 1;
-  animations?: {
-    enabled?: boolean;
-    keyPath?: 'position' | 'position.x' | 'position.y' | 'transform.rotation.x' | 'transform.rotation.y' | 'transform.rotation.z';
-    autoreverses?: 0 | 1;
-    values?: Array<Vec2 | number>;
-    durationSeconds?: number;
-    infinite?: 0 | 1;
-    repeatDurationSeconds?: number;
-  };
+  animations?: Animations;
 };
 
 export type ImageLayer = LayerBase & {
@@ -142,7 +134,7 @@ export type CAStateTransitions = CAStateTransition[];
 export type GyroParallaxDictionary = {
   axis: 'x' | 'y';
   image: string; // always null
-  keyPath: 'position.x' | 'position.y' | 'transform.rotation.x' | 'transform.rotation.y' | 'transform.rotation.z';
+  keyPath: KeyPath;
   layerName: string;
   mapMaxTo: number;
   mapMinTo: number;
@@ -158,4 +150,16 @@ export type CAProjectBundle = {
   stateOverrides?: CAStateOverrides;
   stateTransitions?: CAStateTransitions;
   wallpaperParallaxGroups?: GyroParallaxDictionary[];
+};
+
+export type KeyPath = 'position' | 'position.x' | 'position.y' | 'transform.rotation.x' | 'transform.rotation.y' | 'transform.rotation.z' | 'opacity';
+
+export type Animations = {
+  enabled?: boolean;
+  keyPath?: KeyPath;
+  autoreverses?: 0 | 1;
+  values?: Array<Vec2 | number>;
+  durationSeconds?: number;
+  infinite?: 0 | 1;
+  repeatDurationSeconds?: number;
 };


### PR DESCRIPTION
### Opacity Animations

- Fix animations for text and gradient layers using a new function (`parseCALayerAnimations`)
- Add opacity keyPath to animations tab
- Add some useful types improving code readability

Working tendies (rename .zip to .tendies)
[Opacity.zip](https://github.com/user-attachments/files/22952368/Opacity.zip)
