### PR TITLE
fix: add style tag even if the wallpapers doesnt have transform dictionaries

### DIFF
--- a/apps/web/lib/ca/caml.ts
+++ b/apps/web/lib/ca/caml.ts
@@ -100,11 +100,13 @@ export function parseWallpaperParallaxGroups(xml: string): GyroParallaxDictionar
     if (!wallpaperParallaxGroups) return result;
     
     const dicts = Array.from(wallpaperParallaxGroups.getElementsByTagNameNS(CAML_NS, 'NSDictionary'));
+    const layerNames = Array.from(doc.querySelectorAll('[name]:not([name=""])')).map((el) => el.getAttribute('name'));
     for (const dict of dicts) {
+      const layerName = dict.getElementsByTagNameNS(CAML_NS, 'layerName')[0]?.getAttribute('value') || '';
+      if (!layerNames.includes(layerName)) continue;
       const axis = dict.getElementsByTagNameNS(CAML_NS, 'axis')[0]?.getAttribute('value') || 'x';
       const image = dict.getElementsByTagNameNS(CAML_NS, 'image')[0]?.getAttribute('value') || 'null';
       const keyPath = dict.getElementsByTagNameNS(CAML_NS, 'keyPath')[0]?.getAttribute('value') || 'position.x';
-      const layerName = dict.getElementsByTagNameNS(CAML_NS, 'layerName')[0]?.getAttribute('value') || '';
       const mapMaxTo = Number(dict.getElementsByTagNameNS(CAML_NS, 'mapMaxTo')[0]?.getAttribute('value') || '0');
       const mapMinTo = Number(dict.getElementsByTagNameNS(CAML_NS, 'mapMinTo')[0]?.getAttribute('value') || '0');
       const title = dict.getElementsByTagNameNS(CAML_NS, 'title')[0]?.getAttribute('value') || '';
@@ -674,7 +676,7 @@ export function serializeCAML(
 ): string {
   const doc = document.implementation.createDocument(CAML_NS, 'caml', null);
   const caml = doc.documentElement;
-  const isWallpaperCA = root.children?.some((c) => c.name === 'BACKGROUND' || c.name === 'WALLPAPER');
+  const isWallpaperCA = root.children?.some((c) => c.name === 'BACKGROUND' || c.name === 'FLOATING');
   const capRootLayer: AnyLayer = {
     ...root,
     id: '__capRootLayer__',


### PR DESCRIPTION
### FIX
Gyro wallpapers are getting black when no style tag is attached to the root