### PR TITLE
feat: drag layer as child

### DIFF
--- a/apps/web/components/editor/editor-context.tsx
+++ b/apps/web/components/editor/editor-context.tsx
@@ -10,7 +10,7 @@ import {
   cloneLayerDeep,
   updateInTree,
   removeFromTree,
-  insertBeforeInTree,
+  insertInTree,
   deleteInTree,
   containsId,
   insertIntoSelected,
@@ -70,7 +70,7 @@ export type EditorContextValue = {
   copySelectedLayer: () => void;
   pasteFromClipboard: (payload?: any) => void;
   duplicateLayer: (id?: string) => void;
-  moveLayer: (sourceId: string, beforeId: string | null) => void;
+  moveLayer: (sourceId: string, beforeId: string | null, position?: 'before' | 'after' | 'into') => void;
   persist: () => void;
   undo: () => void;
   redo: () => void;
@@ -1226,7 +1226,7 @@ export function EditorProvider({
     });
   }, [addBase, pushHistory]);
 
-  const moveLayer = useCallback((sourceId: string, beforeId: string | null) => {
+  const moveLayer = useCallback((sourceId: string, beforeId: string | null, position: 'before' | 'after' | 'into' = 'before') => {
     if (!sourceId || sourceId === beforeId) return;
     setDoc((prev) => {
       if (!prev) return prev;
@@ -1237,10 +1237,14 @@ export function EditorProvider({
       if (!node) return prev;
       let nextLayers: AnyLayer[] = removedRes.layers;
       if (beforeId) {
-        const ins = insertBeforeInTree(nextLayers, beforeId, node);
-        nextLayers = ins.layers;
-        if (!ins.inserted) {
-          nextLayers = [...nextLayers, node];
+        if (position === 'into') {
+          nextLayers = insertIntoSelected(nextLayers, beforeId, node);
+        } else {
+          const ins = insertInTree(nextLayers, beforeId, node, position);
+          nextLayers = ins.layers;
+          if (!ins.inserted) {
+            nextLayers = [...nextLayers, node];
+          }
         }
       } else {
         nextLayers = [...nextLayers, node];

--- a/apps/web/lib/editor/layer-utils.ts
+++ b/apps/web/lib/editor/layer-utils.ts
@@ -109,17 +109,23 @@ export function removeFromTree(layers: AnyLayer[], id: string): { removed: AnyLa
   return { removed, layers: next };
 }
 
-export function insertBeforeInTree(layers: AnyLayer[], targetId: string, node: AnyLayer): { inserted: boolean; layers: AnyLayer[] } {
+export function insertInTree(
+  layers: AnyLayer[],
+  targetId: string,
+  node: AnyLayer,
+  position: 'before' | 'after' | 'into' = 'before'
+): { inserted: boolean; layers: AnyLayer[] } {
   let inserted = false;
   const next: AnyLayer[] = [];
   for (let i = 0; i < layers.length; i++) {
     const l = layers[i];
     if (!inserted && l.id === targetId) {
-      next.push(node);
+      if (position === 'before') next.push(node);
       next.push(l);
+      if (position === 'after') next.push(node);
       inserted = true;
     } else if (l.children?.length) {
-      const res = insertBeforeInTree(l.children, targetId, node);
+      const res = insertInTree(l.children, targetId, node, position);
       if (res.inserted) {
         inserted = true;
         next.push({ ...l, children: res.layers } as AnyLayer);


### PR DESCRIPTION
### Add drag-into support for nested layer hierarchy
Implemented the ability to drag layers into other layers to create parent-child relationships in the layers panel.

#### Features:

- Three-zone drop detection: top 25% = before, bottom 25% = after, middle 50% = into
- Visual feedback with highlight when hovering over drop zone
- moveLayer now accepts 'before', 'after', or 'into' position parameter
- Rename insertInTree utility function handles all three insertion modes

#### UX improvements:

- Dragging to the middle of a layer makes it a child
- Drop indicator lines show before/after positions
- Background highlight shows when dropping into a layer