### PR TITLE
feat: add Z position support and 3D transform animations

### DIFF
--- a/apps/web/components/editor/editor-context.tsx
+++ b/apps/web/components/editor/editor-context.tsx
@@ -216,6 +216,7 @@ export function EditorProvider({
               type: 'basic',
               position: { x: meta.width / 2, y: meta.height / 2 },
               size: { w: meta.width, h: meta.height },
+              backgroundColor: "#e5e7eb",
               children: [],
             })
             layers.push({
@@ -224,6 +225,7 @@ export function EditorProvider({
               type: 'basic',
               position: { x: meta.width / 2, y: meta.height / 2 },
               size: { w: meta.width, h: meta.height },
+              backgroundColor: "#e5e7eb",
               children: [],
             })
           }
@@ -1027,7 +1029,7 @@ export function EditorProvider({
       const x = (parentLayer?.size.w || canvasW) / 2;
       const y = (parentLayer?.size.h || canvasH) / 2;
       const layer: ShapeLayer = {
-        ...addBase("Shape Layer"),
+        ...addBase("Basic Layer"),
         type: "shape",
         position: { x, y },
         size: { w: 120, h: 120 },

--- a/apps/web/components/editor/inspector/canvas/LayerRenderer.tsx
+++ b/apps/web/components/editor/inspector/canvas/LayerRenderer.tsx
@@ -87,6 +87,7 @@ export function LayerRenderer({
 
   const x = transformedX ?? animationOverrides['position.x'] ?? layer.position.x;
   const y = transformedY ?? animationOverrides['position.y'] ?? layer.position.y;
+  const z = animationOverrides['zPosition'] ?? layer.zPosition;
   const rotation = animationOverrides['transform.rotation.z'] ?? layer.rotation;
   const rotationX = animationOverrides['transform.rotation.x'] ?? layer.rotationX;
   const rotationY = animationOverrides['transform.rotation.y'] ?? layer.rotationY;
@@ -132,13 +133,22 @@ export function LayerRenderer({
   const translateY = useYUp
     ? -y - ((1 - anchor.y) * height)
     : y - (anchor.y * height);
+  const translateZ = z;
+  const transforms = [
+    `translateX(${translateX}px)`,
+    `translateY(${translateY}px)`,
+    `translateZ(${translateZ}px)`,
+    `rotate(${-(rotation ?? 0)}deg)`,
+    `rotateY(${(rotationY ?? 0)}deg)`,
+    `rotateX(${-(rotationX ?? 0)}deg)`,
+  ];
   const common: React.CSSProperties = {
     position: "absolute",
     left: 0,
     top: useYUp ? '100%' : 0,
     width,
     height,
-    transform: `translateX(${translateX}px) translateY(${translateY}px) rotateX(${-(rotationX ?? 0)}deg) rotateY(${-(rotationY ?? 0)}deg) rotate(${-(rotation ?? 0)}deg)`,
+    transform: transforms.join(' '),
     transformOrigin: `${anchor.x * 100}% ${transformOriginY}%`,
     backfaceVisibility: "visible",
     display: (layer.visible === false || hiddenLayerIds.has(layer.id)) ? "none" : undefined,

--- a/apps/web/components/editor/inspector/index.tsx
+++ b/apps/web/components/editor/inspector/index.tsx
@@ -96,6 +96,7 @@ export function Inspector() {
   const {
     disablePosX,
     disablePosY,
+    disablePosZ,
     disableRotX,
     disableRotY,
     disableRotZ,
@@ -108,6 +109,7 @@ export function Inspector() {
     return {
       disablePosX: on(kp === 'position' || kp === 'position.x'),
       disablePosY: on(kp === 'position' || kp === 'position.y'),
+      disablePosZ: on(kp === 'zPosition'),
       disableRotX: selectedBase?.type === 'emitter' || on(kp === 'transform.rotation.x'),
       disableRotY: selectedBase?.type === 'emitter' || on(kp === 'transform.rotation.y'),
       disableRotZ: on(kp === 'transform.rotation.z'),
@@ -134,7 +136,7 @@ export function Inspector() {
     if (selected?.type === 'video') {
       baseTabs.push({ id: 'video' as TabId, icon: Video, label: 'Video' });
     }
-    if (selected?.type !== 'transform' && selected?.type !== 'video') {
+    if (selected?.type !== 'video') {
       baseTabs.push({ id: 'animations' as TabId, icon: Play, label: 'Animations' });
     }
     if (doc?.meta.gyroEnabled && selected?.type === 'transform') {
@@ -173,7 +175,7 @@ export function Inspector() {
       setActiveTab('emitter');
     } else if (selected?.type === 'replicator' && (['animations', 'text', 'gradient', 'image', 'video', 'content', 'emitter', 'gyro'].includes(activeTab))) {
       setActiveTab('replicator');
-    } else if (selected?.type === 'transform' && (['animations', 'text', 'gradient', 'image', 'video', 'emitter', 'replicator'].includes(activeTab))) {
+    } else if (selected?.type === 'transform' && (['text', 'gradient', 'image', 'video', 'emitter', 'replicator'].includes(activeTab))) {
       setActiveTab('gyro');
     }
   }, [selected?.type, activeTab]);
@@ -352,6 +354,7 @@ export function Inspector() {
               {...tabProps}
               disablePosX={disablePosX}
               disablePosY={disablePosY}
+              disablePosZ={disablePosZ}
               disableRotX={disableRotX}
               disableRotY={disableRotY}
               disableRotZ={disableRotZ}

--- a/apps/web/components/editor/inspector/tabs/GeometryTab.tsx
+++ b/apps/web/components/editor/inspector/tabs/GeometryTab.tsx
@@ -18,6 +18,7 @@ import { getParentAbsContextFor } from "../../canvas-preview/utils/coordinates";
 interface GeometryTabProps extends InspectorTabProps {
   disablePosX: boolean;
   disablePosY: boolean;
+  disablePosZ: boolean;
   disableRotX: boolean;
   disableRotY: boolean;
   disableRotZ: boolean;
@@ -36,6 +37,7 @@ export function GeometryTab({
   fmt0,
   disablePosX,
   disablePosY,
+  disablePosZ,
   disableRotX,
   disableRotY,
   disableRotZ,
@@ -171,6 +173,27 @@ export function GeometryTab({
               const num = v === "" ? 0 : round2(Number(v));
               updateLayer(selected.id, { position: { ...selected.position, y: num } as any });
               clearBuf('pos-y');
+            }} />
+        </div>
+        <div className="space-y-1 col-span-2">
+          <Label htmlFor="pos-z">Z</Label>
+          <Input id="pos-z" type="number" step="0.01" value={getBuf('pos-z', fmt2(selected.zPosition))}
+            disabled={disablePosZ}
+            onChange={(e) => {
+              setBuf('pos-z', e.target.value);
+              const v = e.target.value.trim();
+              if (v === "") return;
+              const num = round2(Number(v));
+              if (Number.isFinite(num)) {
+                updateLayerTransient(selected.id, { zPosition: num });
+              }
+            }}
+            onKeyDown={(e) => { if (e.key === 'Enter') { (e.target as HTMLInputElement).blur(); e.preventDefault(); } }}
+            onBlur={(e) => {
+              const v = e.target.value.trim();
+              const num = v === "" ? 0 : round2(Number(v));
+              updateLayer(selected.id, { zPosition: num });
+              clearBuf('pos-z');
             }} />
         </div>
         {showAlignButtons && (

--- a/apps/web/lib/ca/caml.ts
+++ b/apps/web/lib/ca/caml.ts
@@ -601,11 +601,13 @@ function parseCAEmitterLayer(el: Element): AnyLayer {
 function parseCATransformLayer(el: Element): AnyLayer {
   const base = parseLayerBase(el);
   const children = parseSublayers(el);
+  const parsedAnimations = parseCALayerAnimations(el);
 
   return {
     ...base,
     type: 'transform',
     children,
+    ...(parsedAnimations ? { animations: parsedAnimations } : {} as any),
   } as AnyLayer;
 }
 

--- a/apps/web/lib/ca/serialize/serializeLayer.ts
+++ b/apps/web/lib/ca/serialize/serializeLayer.ts
@@ -489,7 +489,15 @@ export function serializeLayer(
   const animations = layer.animations || []
   if (animations.length > 0) {
     const animationsEl = doc.createElementNS(CAML_NS, 'animations');
-    animations.forEach((anim, index) => {
+    // This ensures proper 3D transformation order: rotation.y must be processed before other rotation properties to avoid flickering
+    const orderedAnimations = [...animations].sort((a, b) => {
+      const priority = (kp: unknown) => {
+        if (kp === 'transform.rotation.y') return 0;
+        return 1;
+      };
+      return priority(a?.keyPath) - priority(b?.keyPath);
+    });
+    orderedAnimations.forEach((anim, index) => {
       if (anim?.enabled && Array.isArray(anim.values) && anim.values.length > 0) {
         const keyPath = (anim.keyPath ?? 'position') as KeyPath;
         const a = doc.createElementNS(CAML_NS, index == 0 ? 'animation' : 'p');


### PR DESCRIPTION
### Feature

- Add zPosition property to basic layers
- Add Z position input field in geometry tab with animation disable support
- Include translateZ in layer transform calculations
- Enable animations for transform layers by parsing from CAML
- Fix 3D transform flickering by ordering rotation.y animations first in serialization
- Rename "Shape Layer" to "Basic Layer" for consistency