### PR TITLE
fix: add webkit-backdrop-filter for desktop app compatibility

### DIFF
--- a/apps/web/components/editor/inspector/canvas/LiquidGlassRenderer.tsx
+++ b/apps/web/components/editor/inspector/canvas/LiquidGlassRenderer.tsx
@@ -36,14 +36,17 @@ export default function LiquidGlassRenderer({
     depth,
   }), [height, width, radius, depth]);
 
+  // 在 LiquidGlassRenderer.tsx 中修改 style 的定义
   let style: CSSProperties = useMemo(() => ({
     height: `${height}px`,
     width: `${width}px`,
     borderRadius: `${radius}px`,
+    WebkitBackdropFilter: `url('${filter}')`, // 添加这一行
     backdropFilter: `url('${filter}')`,
     background: debug ? `url("${map}")` : "none",
     boxShadow: "none",
-  }), [filter, map]);
+    transform: 'translateZ(0)', // 强制开启 GPU 合成层
+  }), [filter, map, height, width, radius, debug]);
 
   return (
     <div style={style}>


### PR DESCRIPTION
问题描述： 在使用 Nativefier 或 Electron 将项目打包为本地桌面应用时，backdrop-filter 在某些 WebKit 内核环境下无法正常调用 GPU 渲染，导致“液态玻璃”图层显示为不透明的白色方块或渲染失败。
Description
Issue: When packaging the project as a local desktop application using Nativefier or Electron, the backdrop-filter property fails to trigger GPU rendering in certain WebKit-based environments. This causes the "Liquid Glass" layer to render as an opaque white box or fail to display correctly.

修复方案： 在 LiquidGlassRenderer.tsx 中为相关样式添加了 -webkit-backdrop-filter 属性。这确保了在所有基于 WebKit 的封装环境（如本地部署的应用）中都能正确触发 GPU 加速渲染。
Solution: Added the -webkit-backdrop-filter property to the styles in LiquidGlassRenderer.tsx. This ensures that GPU-accelerated rendering is correctly triggered in all WebKit-based wrapper environments (such as locally deployed apps).