### PR TITLE
refactor: remove asset management from layers and implement asset caching

### DIFF
--- a/apps/web/components/editor/ExportDialog.tsx
+++ b/apps/web/components/editor/ExportDialog.tsx
@@ -41,7 +41,7 @@ async function loadLicenseText(license: ExportLicense): Promise<string | null> {
 }
 
 export function ExportDialog() {
-  const { doc, flushPersist } = useEditor();
+  const { doc, flushPersist, cleanupAssets } = useEditor();
   const { toast } = useToast();
   const supabase = getSupabaseBrowserClient();
 
@@ -126,6 +126,7 @@ export function ExportDialog() {
       if (!doc) return false;
       try {
         await flushPersist();
+        await cleanupAssets(); // Remove orphaned asset files before export
       } catch {}
       const proj = await getProject(doc.meta.id);
       const baseName =
@@ -211,6 +212,7 @@ export function ExportDialog() {
       if (!doc) return false;
       try {
         await flushPersist();
+        await cleanupAssets();
       } catch {}
       const proj = await getProject(doc.meta.id);
       const baseName =

--- a/apps/web/components/editor/canvas-preview.tsx
+++ b/apps/web/components/editor/canvas-preview.tsx
@@ -283,7 +283,6 @@ export function CanvasPreview() {
                   layer={layer}
                   useYUp={getRootFlip(doc?.meta.geometryFlipped) === 0}
                   siblings={renderedLayers}
-                  assets={other?.assets}
                   gyroX={gyroX}
                   gyroY={gyroY}
                   useGyroControls={useGyroControls}
@@ -300,7 +299,6 @@ export function CanvasPreview() {
                   layer={layer}
                   useYUp={getRootFlip(doc?.meta.geometryFlipped) === 0}
                   siblings={renderedLayers}
-                  assets={current?.assets}
                   gyroX={gyroX}
                   gyroY={gyroY}
                   useGyroControls={useGyroControls}
@@ -318,7 +316,6 @@ export function CanvasPreview() {
                   layer={layer}
                   useYUp={getRootFlip(doc?.meta.geometryFlipped) === 0}
                   siblings={renderedLayers}
-                  assets={current?.assets}
                   gyroX={gyroX}
                   gyroY={gyroY}
                   useGyroControls={useGyroControls}
@@ -338,7 +335,6 @@ export function CanvasPreview() {
                     layer={layer}
                     useYUp={getRootFlip(doc?.meta.geometryFlipped) === 0}
                     siblings={renderedLayers}
-                    assets={current?.assets}
                     gyroX={gyroX}
                     gyroY={gyroY}
                     useGyroControls={useGyroControls}
@@ -352,7 +348,6 @@ export function CanvasPreview() {
                     layer={layer}
                     useYUp={getRootFlip(doc?.meta.geometryFlipped) === 0}
                     siblings={renderedLayers}
-                    assets={current?.assets}
                     gyroX={gyroX}
                     gyroY={gyroY}
                     useGyroControls={useGyroControls}

--- a/apps/web/components/editor/emitter/EmitterCellThumbnail.tsx
+++ b/apps/web/components/editor/emitter/EmitterCellThumbnail.tsx
@@ -1,0 +1,41 @@
+import { useAssetUrl } from "@/hooks/use-asset-url";
+
+interface EmitterCellThumbnailProps {
+  cellId: string;
+  cellSrc?: string;
+  size?: number;
+  className?: string;
+}
+
+export default function EmitterCellThumbnail({
+  cellId,
+  cellSrc,
+  size = 20,
+  className = "object-contain",
+}: EmitterCellThumbnailProps) {
+  const { src, loading } = useAssetUrl({
+    cacheKey: cellId,
+    assetSrc: cellSrc,
+    skip: !cellSrc,
+  });
+
+  if (loading || !src) {
+    return (
+      <div
+        style={{ width: size, height: size }}
+        className="bg-muted rounded animate-pulse"
+      />
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt="Cell"
+      width={size}
+      height={size}
+      className={className}
+    />
+  );
+}
+

--- a/apps/web/components/editor/inspector/canvas/ImageRenderer.tsx
+++ b/apps/web/components/editor/inspector/canvas/ImageRenderer.tsx
@@ -1,21 +1,22 @@
 import { ImageLayer } from "@/lib/ca/types";
+import { useAssetUrl } from "@/hooks/use-asset-url";
 
 interface ImageRendererProps {
   layer: ImageLayer;
-  assets?: Record<string, { dataURL?: string }>;
 }
 
 export default function ImageRenderer({
   layer,
-  assets,
 }: ImageRendererProps) {
-  const assetsMap = assets || {};
-  const imgAsset = assetsMap[layer.id];
-  const previewSrc = imgAsset?.dataURL || layer.src;
-  if (!previewSrc) return null;
+  const { src, loading } = useAssetUrl({
+    cacheKey: layer.id,
+    assetSrc: layer.src,
+  });
+
+  if (loading || !src) return null;
   return (
     <img
-      src={previewSrc}
+      src={src}
       alt={layer.name}
       style={{
         width: "100%",

--- a/apps/web/components/editor/inspector/canvas/LayerRenderer.tsx
+++ b/apps/web/components/editor/inspector/canvas/LayerRenderer.tsx
@@ -21,7 +21,6 @@ interface LayerRendererProps {
   layer: AnyLayer;
   useYUp: boolean;
   siblings: AnyLayer[];
-  assets?: Record<string, { dataURL?: string }>;
   disableHitTesting?: boolean;
   hiddenLayerIds: Set<string>;
   gyroX: number;
@@ -55,7 +54,6 @@ export function LayerRenderer({
   layer: initialLayer,
   useYUp,
   siblings,
-  assets,
   disableHitTesting = false,
   hiddenLayerIds,
   gyroX,
@@ -113,7 +111,6 @@ export function LayerRenderer({
           layer={c}
           useYUp={nextUseYUp}
           siblings={layer.children || []}
-          assets={assets}
           hiddenLayerIds={hiddenLayerIds}
           gyroX={gyroX}
           gyroY={gyroY}
@@ -238,16 +235,16 @@ export function LayerRenderer({
           <TextRenderer layer={layer} />
         )}
         {layer.type === "image" && (
-          <ImageRenderer layer={layer} assets={assets} />
+          <ImageRenderer layer={layer} />
         )}
         {layer.type === "video" && (
-          <VideoRenderer layer={layer} assets={assets} />
+          <VideoRenderer layer={layer} />
         )}
         {layer.type === "gradient" && (
           <GradientRenderer layer={layer} />
         )}
         {layer.type === "emitter" && (
-          <EmitterCanvas layer={layer} assets={assets} />
+          <EmitterCanvas layer={layer} />
         )}
         {layer.type !== "replicator" && layer.type !== "video" && renderChildren(layer, nextUseYUp)}
         {layer.type === "replicator" && (
@@ -256,7 +253,6 @@ export function LayerRenderer({
             gyroX={gyroX}
             gyroY={gyroY}
             nextUseYUp={nextUseYUp}
-            assets={assets}
             hiddenLayerIds={hiddenLayerIds}
             useGyroControls={useGyroControls}
             transformOriginY={transformOriginY}

--- a/apps/web/components/editor/inspector/canvas/MoveableOverlay.tsx
+++ b/apps/web/components/editor/inspector/canvas/MoveableOverlay.tsx
@@ -82,7 +82,7 @@ export function MoveableOverlay({
       });
   }, [renderedLayers, selectedLayer]);
 
-  const targetRef = useRef<HTMLElement>(null);
+  const [targetRef, setTargetRef] = useState<HTMLElement | null>(null);
   const [keepRatio, setKeepRatio] = useState(false);
   const [currentRotation, setCurrentRotation] = useState(0);
   const [currentTranslation, setCurrentTranslation] = useState({
@@ -98,7 +98,7 @@ export function MoveableOverlay({
   
   useEffect(() => {
     if (!selectedLayer) return;
-    targetRef.current = document.getElementById(selectedLayer.id);
+    setTargetRef(document.getElementById(selectedLayer.id));
   }, [selectedLayer, path]);
 
   if (!selectedLayer) return null;
@@ -143,7 +143,7 @@ export function MoveableOverlay({
         dist,
         transform,
       }) => {
-        const useYUp = targetRef.current?.getAttribute('data-y-up') === 'true';
+        const useYUp = targetRef?.getAttribute('data-y-up') === 'true';
         setCurrentTranslation({
           x: dist[0],
           y: useYUp ? -dist[1] : dist[1],
@@ -205,7 +205,7 @@ export function MoveableOverlay({
       }) => {
         delta[0] && (target!.style.width = `${width}px`);
         delta[1] && (target!.style.height = `${height}px`);
-        const useYUp = targetRef.current?.getAttribute('data-y-up') === 'true';
+        const useYUp = targetRef?.getAttribute('data-y-up') === 'true';
         setCurrentSize({
           w: width,
           h: height,

--- a/apps/web/components/editor/inspector/canvas/ReplicatorRenderer.tsx
+++ b/apps/web/components/editor/inspector/canvas/ReplicatorRenderer.tsx
@@ -9,7 +9,6 @@ export default function ReplicatorRenderer({
   useGyroControls,
   transformOriginY,
   nextUseYUp,
-  assets,
   hiddenLayerIds,
   anchor,
 }: {
@@ -19,7 +18,6 @@ export default function ReplicatorRenderer({
   useGyroControls: boolean;
   transformOriginY: number;
   nextUseYUp: boolean;
-  assets?: Record<string, { dataURL?: string }>;
   hiddenLayerIds: Set<string>;
   anchor: { x: number; y: number };
 }) {
@@ -61,7 +59,6 @@ export default function ReplicatorRenderer({
                 layer={c}
                 useYUp={nextUseYUp}
                 siblings={layer.children || []}
-                assets={assets}
                 disableHitTesting={i > 0}
                 hiddenLayerIds={hiddenLayerIds}
                 gyroX={gyroX}

--- a/apps/web/components/editor/inspector/index.tsx
+++ b/apps/web/components/editor/inspector/index.tsx
@@ -383,7 +383,6 @@ export function Inspector() {
               updateLayer={updateLayer}
               replaceImageForLayer={replaceImageForLayer}
               activeState={current?.activeState}
-              assets={current?.assets}
             />
           )}
 
@@ -395,7 +394,6 @@ export function Inspector() {
             <EmitterTab
               {...tabProps}
               addEmitterCellImage={addEmitterCellImage}
-              assets={current?.assets}
             />
           )}
 

--- a/apps/web/components/editor/inspector/tabs/EmitterTab.tsx
+++ b/apps/web/components/editor/inspector/tabs/EmitterTab.tsx
@@ -8,15 +8,14 @@ import { type InspectorTabProps } from "../types";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useEditor } from "../../editor-context";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import EmitterCellThumbnail from "../../emitter/EmitterCellThumbnail";
 
 interface EmitterTabProps extends InspectorTabProps {
-  assets?: Record<string, { filename: string; dataURL: string }>;
   activeState?: string;
   addEmitterCellImage: (layerId: string, file: File) => Promise<void>;
 }
 
 export function EmitterTab({
-  assets,
   selected,
   updateLayer,
   updateLayerTransient,
@@ -208,12 +207,10 @@ export function EmitterTab({
             <AccordionItem key={cell.id} value={cell.id}>
               <AccordionTrigger>
                 <div className="flex items-center gap-2">
-                  <img
-                    src={assets?.[cell.id]?.dataURL}
-                    alt={`Cell ${i}`}
-                    width={20}
-                    height={20}
-                    className="object-contain"
+                  <EmitterCellThumbnail
+                    cellId={cell.id}
+                    cellSrc={cell.src}
+                    size={20}
                   />
                   Cell {i + 1}
                 </div>

--- a/apps/web/hooks/use-asset-url.ts
+++ b/apps/web/hooks/use-asset-url.ts
@@ -1,0 +1,336 @@
+import { useEffect, useState } from "react";
+import { getFile } from "@/lib/storage";
+import { useEditor } from "@/components/editor/editor-context";
+import { CAEmitterCell } from "@/components/editor/emitter/emitter";
+
+class AssetCache {
+  private cache = new Map<string, string>();
+  private accessOrder: string[] = [];
+
+  get(id: string): string | null {
+    const data = this.cache.get(id);
+    if (data) {
+      this.accessOrder = this.accessOrder.filter((k) => k !== id);
+      this.accessOrder.push(id);
+    }
+    return data || null;
+  }
+
+  set(id: string, url: string) {
+    this.cache.set(id, url);
+    this.accessOrder = this.accessOrder.filter((k) => k !== id);
+    this.accessOrder.push(id);
+  }
+
+  has(id: string): boolean {
+    return this.cache.has(id);
+  }
+
+  clear() {
+    this.cache.forEach((url) => URL.revokeObjectURL(url));
+    this.cache.clear();
+    this.accessOrder = [];
+  }
+}
+
+export const assetCache = new AssetCache();
+
+function buildAssetPaths(projectName: string, assetSrc: string): string[] {
+  return [
+    `${projectName}.ca/Floating.ca/${assetSrc}`,
+    `${projectName}.ca/Background.ca/${assetSrc}`,
+    `${projectName}.ca/Wallpaper.ca/${assetSrc}`,
+  ];
+}
+
+interface UseAssetUrlOptions {
+  cacheKey: string;
+  assetSrc?: string;
+  skip?: boolean;
+}
+
+interface UseAssetUrlResult {
+  src: string | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useAssetUrl({
+  cacheKey,
+  assetSrc,
+  skip = false,
+}: UseAssetUrlOptions): UseAssetUrlResult {
+  const { doc } = useEditor();
+  const projectId = doc?.meta.id ?? "";
+  const projectName = doc?.meta.name ?? "";
+  const [src, setSrc] = useState<string | null>(() => assetCache.get(cacheKey));
+  const [loading, setLoading] = useState(!assetCache.has(cacheKey) && !skip);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (skip || !assetSrc) {
+      setLoading(false);
+      return;
+    }
+
+    const cached = assetCache.get(cacheKey);
+    if (cached) {
+      setSrc(cached);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchAsset() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const paths = buildAssetPaths(projectName, assetSrc!);
+        let buf: ArrayBuffer | undefined;
+        for (const path of paths) {
+          const file = await getFile(projectId, path);
+          if (file?.data && file.data instanceof ArrayBuffer) {
+            buf = file.data;
+            break;
+          }
+        }
+
+        if (cancelled) return;
+
+        if (!buf) {
+          setLoading(false);
+          return;
+        }
+
+        const blob = new Blob([buf]);
+        const url = URL.createObjectURL(blob);
+
+        assetCache.set(cacheKey, url);
+        setSrc(url);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchAsset();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cacheKey, projectId, projectName, assetSrc, skip]);
+
+  return { src, loading, error };
+}
+
+interface UseVideoFramesOptions {
+  videoId: string;
+  frameCount: number;
+  framePrefix: string;
+  frameExtension: string;
+  skip?: boolean;
+}
+
+interface UseVideoFramesResult {
+  frames: Map<number, string>;
+  loading: boolean;
+}
+
+export function useVideoFrames({
+  videoId,
+  frameCount,
+  framePrefix,
+  frameExtension,
+  skip = false,
+}: UseVideoFramesOptions): UseVideoFramesResult {
+  const { doc } = useEditor();
+  const projectId = doc?.meta.id ?? "";
+  const projectName = doc?.meta.name ?? "";
+  const [frames, setFrames] = useState<Map<number, string>>(() => {
+    const cached = new Map<number, string>();
+    for (let i = 0; i < frameCount; i++) {
+      const url = assetCache.get(`${videoId}_frame_${i}`);
+      if (url) cached.set(i, url);
+    }
+    return cached;
+  });
+  const [loading, setLoading] = useState(!skip && frames.size < frameCount);
+
+  useEffect(() => {
+    if (skip || frameCount <= 0) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadAllFrames() {
+      setLoading(true);
+      const loadedFrames = new Map<number, string>();
+
+      for (let i = 0; i < frameCount; i++) {
+        if (cancelled) return;
+
+        const frameAssetId = `${videoId}_frame_${i}`;
+        const frameName = `${framePrefix}${i}${frameExtension}`;
+
+        const cached = assetCache.get(frameAssetId);
+        if (cached) {
+          loadedFrames.set(i, cached);
+          continue;
+        }
+
+        try {
+          const paths = [
+            `${projectName}.ca/Floating.ca/assets/${frameName}`,
+            `${projectName}.ca/Background.ca/assets/${frameName}`,
+            `${projectName}.ca/Wallpaper.ca/assets/${frameName}`,
+          ];
+
+          let buf: ArrayBuffer | undefined;
+          for (const path of paths) {
+            const file = await getFile(projectId, path);
+            if (file?.data && file.data instanceof ArrayBuffer) {
+              buf = file.data;
+              break;
+            }
+          }
+
+          if (buf) {
+            const blob = new Blob([buf]);
+            const url = URL.createObjectURL(blob);
+            loadedFrames.set(i, url);
+            assetCache.set(frameAssetId, url);
+          }
+        } catch (err) {
+          console.error(`Failed to load frame ${i}:`, err);
+        }
+      }
+
+      if (!cancelled) {
+        setFrames(loadedFrames);
+        setLoading(false);
+      }
+    }
+
+    loadAllFrames();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [videoId, frameCount, framePrefix, frameExtension, projectId, projectName, skip]);
+
+  return { frames, loading };
+}
+
+interface UseEmitterCellImagesOptions {
+  cells: CAEmitterCell[];
+  skip?: boolean;
+}
+
+interface UseEmitterCellImagesResult {
+  cellImages: Map<string, HTMLImageElement>;
+  loading: boolean;
+}
+
+const loadImage = (src: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const img = new Image();
+    img.decoding = "async";
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = src;
+  });
+
+export function useEmitterCellImages({
+  cells,
+  skip = false,
+}: UseEmitterCellImagesOptions): UseEmitterCellImagesResult {
+  const { doc } = useEditor();
+  const projectId = doc?.meta.id ?? "";
+  const projectName = doc?.meta.name ?? "";
+
+  const [cellImages, setCellImages] = useState<Map<string, HTMLImageElement>>(
+    () => new Map()
+  );
+  const [loading, setLoading] = useState(!skip && cells.length > 0);
+
+  useEffect(() => {
+    if (skip || cells.length === 0) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadAllCellImages() {
+      setLoading(true);
+      const loadedImages = new Map<string, HTMLImageElement>();
+
+      for (const cell of cells) {
+        if (cancelled) return;
+
+        const cached = assetCache.get(cell.id);
+        if (cached) {
+          try {
+            const img = await loadImage(cached);
+            loadedImages.set(cell.id, img);
+          } catch (err) {
+            console.error(`Failed to load cached image for cell ${cell.id}:`, err);
+          }
+          continue;
+        }
+
+        if (cell.src) {
+          try {
+            const paths = [
+              `${projectName}.ca/Floating.ca/${cell.src}`,
+              `${projectName}.ca/Background.ca/${cell.src}`,
+              `${projectName}.ca/Wallpaper.ca/${cell.src}`,
+            ];
+
+            let buf: ArrayBuffer | undefined;
+            for (const path of paths) {
+              const file = await getFile(projectId, path);
+              if (file?.data && file.data instanceof ArrayBuffer) {
+                buf = file.data;
+                break;
+              }
+            }
+
+            if (buf) {
+              const blob = new Blob([buf]);
+              const url = URL.createObjectURL(blob);
+              const img = await loadImage(url);
+              loadedImages.set(cell.id, img);
+              assetCache.set(cell.id, url);
+            }
+          } catch (err) {
+            console.error(`Failed to load cell image ${cell.id}:`, err);
+          }
+        }
+      }
+
+      if (!cancelled) {
+        setCellImages(loadedImages);
+        setLoading(false);
+      }
+    }
+
+    loadAllCellImages();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [JSON.stringify(cells.map((c) => ({ id: c.id, src: c.src }))), projectId, projectName, skip]);
+
+  return { cellImages, loading };
+}
+

--- a/apps/web/lib/editor/file-utils.ts
+++ b/apps/web/lib/editor/file-utils.ts
@@ -1,3 +1,6 @@
+import { putBlobFilesBatch, listFiles, deleteFile } from "@/lib/storage";
+import type { AnyLayer, ImageLayer, VideoLayer, EmitterLayer } from "@/lib/ca/types";
+
 export function sanitizeFilename(name: string): string {
   const n = (name || '').trim();
   if (!n) return '';
@@ -30,3 +33,111 @@ export const normalize = (s: string) => {
   try { s = decodeURIComponent(s); } catch {}
   return (s || '').trim().toLowerCase();
 };
+
+export interface FrameAsset {
+  dataURL: string;
+  filename: string;
+}
+
+export function collectReferencedAssets(layers: AnyLayer[]): Set<string> {
+  const referenced = new Set<string>();
+
+  const walk = (layerList: AnyLayer[]) => {
+    for (const layer of layerList) {
+      if (layer.type === "image") {
+        const img = layer as ImageLayer;
+        if (img.src) {
+          const filename = img.src.split("/").pop();
+          if (filename) referenced.add(normalize(filename));
+        }
+      }
+
+      if (layer.type === "video") {
+        const video = layer as VideoLayer;
+        const frameCount = video.frameCount || 0;
+        const prefix = video.framePrefix || "";
+        const ext = video.frameExtension || "";
+        for (let i = 0; i < frameCount; i++) {
+          referenced.add(normalize(`${prefix}${i}${ext}`));
+        }
+      }
+
+      if (layer.type === "emitter") {
+        const emitter = layer as EmitterLayer;
+        for (const cell of emitter.emitterCells || []) {
+          if (cell.src) {
+            const filename = cell.src.split("/").pop();
+            if (filename) referenced.add(normalize(filename));
+          }
+        }
+      }
+
+      if (layer.children?.length) {
+        walk(layer.children);
+      }
+    }
+  };
+
+  walk(layers);
+  return referenced;
+}
+
+export async function cleanupOrphanedAssets(
+  projectId: string,
+  projectName: string,
+  caFolder: "Floating.ca" | "Background.ca" | "Wallpaper.ca",
+  layers: AnyLayer[]
+): Promise<number> {
+  const folder = `${projectName}.ca`;
+  const assetsPrefix = `${folder}/${caFolder}/assets/`;
+
+  const allFiles = await listFiles(projectId, assetsPrefix);
+  if (!allFiles.length) return 0;
+
+  const referenced = collectReferencedAssets(layers);
+  let deletedCount = 0;
+  for (const file of allFiles) {
+    const filename = file.path.split("/assets/").pop();
+    if (!filename) continue;
+
+    const normalizedFilename = normalize(filename);
+    if (!referenced.has(normalizedFilename)) {
+      try {
+        const assetPath = `${caFolder}/assets/${filename}`;
+        await deleteFile(projectId, assetPath);
+        deletedCount++;
+      } catch (err) {
+        console.error(`Failed to delete orphaned asset: ${file.path}`, err);
+      }
+    }
+  }
+
+  return deletedCount;
+}
+
+export async function uploadFrameAssets(
+  projectId: string,
+  folder: string,
+  caFolder: string,
+  frameAssets: FrameAsset[]
+): Promise<boolean> {
+  const assetFiles: Array<{ path: string; data: Blob }> = [];
+
+  for (const frame of frameAssets) {
+    try {
+      const blob = await dataURLToBlob(frame.dataURL);
+      const assetPath = `${folder}/${caFolder}/assets/${frame.filename}`;
+      assetFiles.push({ path: assetPath, data: blob });
+    } catch (err) {
+      console.error("Failed to prepare asset:", frame.filename, err);
+    }
+  }
+
+  try {
+    await putBlobFilesBatch(projectId, assetFiles);
+    return true;
+  } catch (err) {
+    console.error("Failed to write assets batch:", err);
+    return false;
+  }
+}


### PR DESCRIPTION
### Refactor

- Removed asset references from various components including CanvasPreview, Inspector, and LayerRenderer.
- Introduced a new asset caching mechanism using `useAssetUrl` hook for efficient asset loading.
- Updated asset handling in video and image layers to utilize the new caching system.
- Implemented cleanup of orphaned assets in the export process to ensure no unused files remain.
- Added EmitterCellThumbnail component for better rendering of emitter cell images.